### PR TITLE
Changed CMake Visual Studio generator checks to MSVC

### DIFF
--- a/script/max-posttarget.cmake
+++ b/script/max-posttarget.cmake
@@ -66,7 +66,7 @@ elseif (WIN32)
 	
 	set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".mxe64")
 
-	if (CMAKE_GENERATOR MATCHES "Visual Studio")
+	if (MSVC)
 		# warning about constexpr not being const in c++14
 		set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4814")
 

--- a/script/max-pretarget.cmake
+++ b/script/max-pretarget.cmake
@@ -9,7 +9,7 @@ if (WIN32)
 	# These must be prior to the "project" command
 	# https://stackoverflow.com/questions/14172856/compile-with-mt-instead-of-md-using-cmake
 
-	if (CMAKE_GENERATOR MATCHES "Visual Studio")
+	if (MSVC)
 		set(CMAKE_C_FLAGS_DEBUG            "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")
 		set(CMAKE_C_FLAGS_MINSIZEREL       "/MT /O1 /Ob1 /D NDEBUG")
 		set(CMAKE_C_FLAGS_RELEASE          "/MT /O2 /Ob2 /D NDEBUG")


### PR DESCRIPTION
This allows use of generators which are not Visual Studio (e.g. CLion, which identifies to CMake as 'Unix Makefiles') but compile using MSVC.