### PR TITLE
Add include for ext_proto.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /script/verinfo.rc
+.DS_Store

--- a/c74support/c74_max.h
+++ b/c74support/c74_max.h
@@ -22,6 +22,7 @@ namespace max {
 #include "max-includes/jgraphics.h"
 #include "max-includes/ext_parameter.h"
 #include "max-includes/ext_boxstyle.h"
+#include "max-includes/ext_proto.h"
 
 #undef min
 #undef max


### PR DESCRIPTION
Brings in filewatcher prototype so that they can be used in Min.