### PR TITLE
Fix: "C74DebugBreak" redefined [-Werror]

### DIFF
--- a/c74support/max-includes/ext_prefix.h
+++ b/c74support/max-includes/ext_prefix.h
@@ -157,7 +157,9 @@
 #endif
 
 // debug support
-#if defined (__GNUC__) && defined(C74_X64)
+#ifdef WIN_VERSION
+#define C74DebugBreak DebugBreak()
+#elif defined (__GNUC__) && defined(C74_X64)
 #ifndef C74DebugBreak
 #ifdef __x86_64__
 #define C74DebugBreak asm("int3")
@@ -167,10 +169,6 @@
 #warning implement me
 #endif
 #endif
-#endif
-
-#ifdef WIN_VERSION
-#define C74DebugBreak DebugBreak()
 #endif
 
 #ifndef C74_STR


### PR DESCRIPTION
Debug macro definition was not checking if it was previously defined.
This caused the error: `"C74DebugBreak" redefined` when compiling under Ubuntu with x86_64-w64-mingw32-gcc compiler for Windows x64.

The patch I propose just inverts the order of the macro definitions, which does not cause macro redefinition because of the `#elif` and the `#ifndef`.